### PR TITLE
add advanced period support

### DIFF
--- a/src/time_unit/mod.rs
+++ b/src/time_unit/mod.rs
@@ -15,7 +15,7 @@ pub use self::seconds::Seconds;
 pub use self::years::Years;
 
 use error::*;
-use schedule::{Ordinal, OrdinalSet, Specifier};
+use schedule::{Ordinal, OrdinalSet, RootSpecifier, Specifier};
 use std::borrow::Cow;
 use std::collections::btree_set;
 use std::iter;
@@ -222,16 +222,6 @@ where
         match *specifier {
             All => Ok(Self::supported_ordinals()),
             Point(ordinal) => Ok((&[ordinal]).iter().cloned().collect()),
-            NamedPoint(ref name) => Ok((&[Self::ordinal_from_name(name)?])
-                .iter()
-                .cloned()
-                .collect()),
-            Period(start, step) => {
-                let start = Self::validate_ordinal(start)?;
-                Ok((start..Self::inclusive_max() + 1)
-                    .step_by(step as usize)
-                    .collect())
-            }
             Range(start, end) => {
                 match (Self::validate_ordinal(start), Self::validate_ordinal(end)) {
                     (Ok(start), Ok(end)) if start <= end => Ok((start..end + 1).collect()),
@@ -257,5 +247,28 @@ where
                 }
             }
         }
+    }
+
+    fn ordinals_from_root_specifier(root_specifier: &RootSpecifier) -> Result<OrdinalSet> {
+        let ordinals = match root_specifier {
+            RootSpecifier::Specifier(specifier) => Self::ordinals_from_specifier(&specifier)?,
+            RootSpecifier::Period(start, step) => {
+                let base_set = match start {
+                    // A point prior to a period implies a range whose start is the specified
+                    // point and terminating inclusively with the inclusive max
+                    Specifier::Point(start) => {
+                        let start = Self::validate_ordinal(*start)?;
+                        (start..Self::inclusive_max() + 1).collect()
+                    }
+                    specifier => Self::ordinals_from_specifier(&specifier)?,
+                };
+                base_set.into_iter().step_by(*step as usize).collect()
+            }
+            RootSpecifier::NamedPoint(ref name) => (&[Self::ordinal_from_name(name)?])
+                .iter()
+                .cloned()
+                .collect::<OrdinalSet>(),
+        };
+        Ok(ordinals)
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,9 +1,11 @@
 extern crate chrono;
+extern crate chrono_tz;
 extern crate cron;
 
 #[cfg(test)]
 mod tests {
     use chrono::*;
+    use chrono_tz::Tz;
     use cron::{Schedule, TimeUnitSpec};
     use std::collections::Bound::{Excluded, Included};
     use std::str::FromStr;
@@ -314,5 +316,174 @@ mod tests {
         let schedule_2 = "00 00 * * * * *".parse::<Schedule>().unwrap();
         let next_time_2 = schedule_2.after(&start_time).next().unwrap();
         assert_eq!(next_time_1, next_time_2);
+    }
+
+    #[test]
+    fn test_period_values_any_dom() {
+        let schedule = Schedule::from_str("0 0 0 ? * *").unwrap();
+        let schedule_tz: Tz = "Europe/London".parse().unwrap();
+        let dt = schedule_tz.ymd(2020, 9, 17).and_hms(0, 0, 0);
+        let mut schedule_iter = schedule.after(&dt);
+        assert_eq!(
+            schedule_tz.ymd(2020, 9, 18).and_hms(0, 0, 0),
+            schedule_iter.next().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_period_values_any_dow() {
+        let schedule = Schedule::from_str("0 0 0 * * ?").unwrap();
+        let schedule_tz: Tz = "Europe/London".parse().unwrap();
+        let dt = schedule_tz.ymd(2020, 9, 17).and_hms(0, 0, 0);
+        let mut schedule_iter = schedule.after(&dt);
+        assert_eq!(
+            schedule_tz.ymd(2020, 9, 18).and_hms(0, 0, 0),
+            schedule_iter.next().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_period_values_all_seconds() {
+        let schedule = Schedule::from_str("*/17 * * * * ?").unwrap();
+        let schedule_tz: Tz = "Europe/London".parse().unwrap();
+        let dt = schedule_tz.ymd(2020, 1, 1).and_hms(0, 0, 0);
+        let mut schedule_iter = schedule.after(&dt);
+        let expected_values = vec![
+            schedule_tz.ymd(2020, 1, 1).and_hms(0, 0, 17),
+            schedule_tz.ymd(2020, 1, 1).and_hms(0, 0, 34),
+            schedule_tz.ymd(2020, 1, 1).and_hms(0, 0, 51),
+            schedule_tz.ymd(2020, 1, 1).and_hms(0, 1, 0),
+            schedule_tz.ymd(2020, 1, 1).and_hms(0, 1, 17),
+            schedule_tz.ymd(2020, 1, 1).and_hms(0, 1, 34),
+        ];
+        for expected_value in expected_values.iter() {
+            assert_eq!(*expected_value, schedule_iter.next().unwrap());
+        }
+    }
+
+    #[test]
+    fn test_period_values_range() {
+        let schedule = Schedule::from_str("0 0 0 1 1-4/2 ?").unwrap();
+        let schedule_tz: Tz = "Europe/London".parse().unwrap();
+        let dt = schedule_tz.ymd(2020, 1, 1).and_hms(0, 0, 0);
+        let mut schedule_iter = schedule.after(&dt);
+        let expected_values = vec![
+            schedule_tz.ymd(2020, 3, 1).and_hms(0, 0, 0),
+            schedule_tz.ymd(2021, 1, 1).and_hms(0, 0, 0),
+            schedule_tz.ymd(2021, 3, 1).and_hms(0, 0, 0),
+            schedule_tz.ymd(2022, 1, 1).and_hms(0, 0, 0),
+        ];
+        for expected_value in expected_values.iter() {
+            assert_eq!(*expected_value, schedule_iter.next().unwrap());
+        }
+    }
+
+    #[test]
+    fn test_period_values_range_hours() {
+        let schedule = Schedule::from_str("0 0 10-12/2 * * ?").unwrap();
+        let schedule_tz: Tz = "Europe/London".parse().unwrap();
+        let dt = schedule_tz.ymd(2020, 1, 1).and_hms(0, 0, 0);
+        let mut schedule_iter = schedule.after(&dt);
+        let expected_values = vec![
+            schedule_tz.ymd(2020, 1, 1).and_hms(10, 0, 0),
+            schedule_tz.ymd(2020, 1, 1).and_hms(12, 0, 0),
+            schedule_tz.ymd(2020, 1, 2).and_hms(10, 0, 0),
+            schedule_tz.ymd(2020, 1, 2).and_hms(12, 0, 0),
+        ];
+        for expected_value in expected_values.iter() {
+            assert_eq!(*expected_value, schedule_iter.next().unwrap());
+        }
+    }
+
+    #[test]
+    fn test_period_values_range_days() {
+        let schedule = Schedule::from_str("0 0 0 1-31/10 * ?").unwrap();
+        let schedule_tz: Tz = "Europe/London".parse().unwrap();
+        let dt = schedule_tz.ymd(2020, 1, 1).and_hms(0, 0, 0);
+        let mut schedule_iter = schedule.after(&dt);
+        let expected_values = vec![
+            schedule_tz.ymd(2020, 1, 11).and_hms(0, 0, 0),
+            schedule_tz.ymd(2020, 1, 21).and_hms(0, 0, 0),
+            schedule_tz.ymd(2020, 1, 31).and_hms(0, 0, 0),
+            schedule_tz.ymd(2020, 2, 1).and_hms(0, 0, 0),
+            schedule_tz.ymd(2020, 2, 11).and_hms(0, 0, 0),
+            schedule_tz.ymd(2020, 2, 21).and_hms(0, 0, 0),
+            schedule_tz.ymd(2020, 3, 1).and_hms(0, 0, 0),
+        ];
+        for expected_value in expected_values.iter() {
+            assert_eq!(*expected_value, schedule_iter.next().unwrap());
+        }
+    }
+
+    #[test]
+    fn test_period_values_range_months() {
+        let schedule = Schedule::from_str("0 0 0 1 January-June/1 *").unwrap();
+        let schedule_tz: Tz = "Europe/London".parse().unwrap();
+        let dt = schedule_tz.ymd(2020, 1, 1).and_hms(0, 0, 0);
+        let mut schedule_iter = schedule.after(&dt);
+        let expected_values = vec![
+            schedule_tz.ymd(2020, 2, 1).and_hms(0, 0, 0),
+            schedule_tz.ymd(2020, 3, 1).and_hms(0, 0, 0),
+            schedule_tz.ymd(2020, 4, 1).and_hms(0, 0, 0),
+            schedule_tz.ymd(2020, 5, 1).and_hms(0, 0, 0),
+            schedule_tz.ymd(2020, 6, 1).and_hms(0, 0, 0),
+            schedule_tz.ymd(2021, 1, 1).and_hms(0, 0, 0),
+        ];
+        for expected_value in expected_values.iter() {
+            assert_eq!(*expected_value, schedule_iter.next().unwrap());
+        }
+    }
+
+    #[test]
+    fn test_period_values_range_years() {
+        let schedule = Schedule::from_str("0 0 0 1 1 ? 2020-2040/10").unwrap();
+        let schedule_tz: Tz = "Europe/London".parse().unwrap();
+        let dt = schedule_tz.ymd(2020, 1, 1).and_hms(0, 0, 0);
+        let mut schedule_iter = schedule.after(&dt);
+        let expected_values = vec![
+            schedule_tz.ymd(2030, 1, 1).and_hms(0, 0, 0),
+            schedule_tz.ymd(2040, 1, 1).and_hms(0, 0, 0),
+        ];
+        for expected_value in expected_values.iter() {
+            assert_eq!(*expected_value, schedule_iter.next().unwrap());
+        }
+    }
+
+    #[test]
+    fn test_period_values_point() {
+        let schedule = Schedule::from_str("0 */21 * * * ?").unwrap();
+        let schedule_tz: Tz = "Europe/London".parse().unwrap();
+        let dt = schedule_tz.ymd(2020, 1, 1).and_hms(0, 0, 0);
+        let mut schedule_iter = schedule.after(&dt);
+        let expected_values = vec![
+            schedule_tz.ymd(2020, 1, 1).and_hms(0, 21, 0),
+            schedule_tz.ymd(2020, 1, 1).and_hms(0, 42, 0),
+            schedule_tz.ymd(2020, 1, 1).and_hms(1, 0, 0),
+            schedule_tz.ymd(2020, 1, 1).and_hms(1, 21, 0),
+            schedule_tz.ymd(2020, 1, 1).and_hms(1, 42, 0),
+            schedule_tz.ymd(2020, 1, 1).and_hms(2, 0, 0),
+            schedule_tz.ymd(2020, 1, 1).and_hms(2, 21, 0),
+            schedule_tz.ymd(2020, 1, 1).and_hms(2, 42, 0),
+        ];
+        for expected_value in expected_values.iter() {
+            assert_eq!(*expected_value, schedule_iter.next().unwrap());
+        }
+    }
+
+    #[test]
+    fn test_period_values_named_range() {
+        let schedule = Schedule::from_str("0 0 0 1 January-April/2 ?").unwrap();
+        let schedule_tz: Tz = "Europe/London".parse().unwrap();
+        let dt = schedule_tz.ymd(2020, 1, 1).and_hms(0, 0, 0);
+        let mut schedule_iter = schedule.after(&dt);
+        let expected_values = vec![
+            schedule_tz.ymd(2020, 3, 1).and_hms(0, 0, 0),
+            schedule_tz.ymd(2021, 1, 1).and_hms(0, 0, 0),
+            schedule_tz.ymd(2021, 3, 1).and_hms(0, 0, 0),
+            schedule_tz.ymd(2022, 1, 1).and_hms(0, 0, 0),
+        ];
+        for expected_value in expected_values.iter() {
+            assert_eq!(*expected_value, schedule_iter.next().unwrap());
+        }
     }
 }


### PR DESCRIPTION
The existing period support requires that the base value be an ordinal. To handle more advanced cases we can allow the base value to be a specifier and then pull out some existing specifier variants into a root specifier. Namely, a root specifier can contain a specifier, a period, or a named point. A specifier can be all, point, range, or named range.

This adds support for cases such as `*/2`, `10-20/2`, and `Mon-Thurs/2`.